### PR TITLE
Short-circuit recursion if max_font_size is too small or min_font_size is too big

### DIFF
--- a/jquery-full-house.js
+++ b/jquery-full-house.js
@@ -148,6 +148,7 @@
 		{
 			var find_max_font_size_starting_with = function(font_size)
 			{
+				font_size = Math.ceil(font_size)
 				if (is_too_big(font_size))
 					return algorythm.too_big(font_size)
 				else


### PR DESCRIPTION
This pull request don't bother running the full recursion if it sees that the font sizes specified by the bounds are already the correct result. This is mainly a performance boost.
